### PR TITLE
bug-fix and feature 

### DIFF
--- a/demo/api.htm
+++ b/demo/api.htm
@@ -199,6 +199,11 @@
                         <td>set to false to hide the Lens</td>
                     </tr>
                     <tr>
+                        <td>minZoomLevel</td>
+                        <td>1.01</td>
+                        <td>The minimum zoom level allowed. Do not set below 1.</td>
+                    </tr>
+                    <tr>
                         <td>borderColour</td>
                         <td>#888</td>
                         <td>Border Colour</td>

--- a/src/jquery.ez-plus.js
+++ b/src/jquery.ez-plus.js
@@ -107,18 +107,26 @@ if (typeof Object.create !== 'function') {
             var self = this;
 
             setTimeout(function () {
-                self.fetch(self.imageSrc);
+                self.fetch(self.imageSrc, self.$elem, self.options.minZoomLevel);
 
             }, length || self.options.refresh);
         },
-        fetch: function (imgsrc) {
+        fetch: function (imgsrc, element, minZoom) {
             //get the image
             var self = this;
             var newImg = new Image();
             newImg.onload = function () {
                 //set the large image dimensions - used to calculte ratio's
-                self.largeWidth = newImg.width;
-                self.largeHeight = newImg.height;
+				if (newImg.width/element.width() <= minZoom){
+					self.largeWidth = element.width()*minZoom;
+				} else {
+				    self.largeWidth = newImg.width;
+				}
+				if (newImg.width/element.height() <= minZoom){
+					self.largeHeight = element.height()*minZoom;
+				} else {
+				    self.largeHeight = newImg.height;
+				}
                 //once image is loaded start the calls
                 self.startZoom();
                 self.currentImage = self.imageSrc;
@@ -1877,7 +1885,7 @@ if (typeof Object.create !== 'function') {
         // allow to continue zooming out, so it keeps retrocompatibility.
         mantainZoomAspectRatio: false,
         maxZoomLevel: false,
-        minZoomLevel: false,
+        minZoomLevel: 1.01,
 
         onComplete: $.noop,
         onDestroy: $.noop,


### PR DESCRIPTION
The plugin currently doesn't work properly when the zoom level is 1.  The zoom window becomes fixed(see below).  Also, it's not helpful if the zoom level is 1 or less.  The fetch method was changed to respect the minZoomLevel parameter you already had.  I set the minZoomLevel to 1.01 to prevent the bug.

here shows the referenced bug
https://jsfiddle.net/086ropgm/embedded/result/

Thank you for taking on this project.  I appreciate the updates!
