### PR TITLE
improve the results of `npm install ez-plus`

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,73 @@
-.DS_Store
+# Ignore Visual Studio  Project #
+###################
+*.user
+*.gpState
+*.suo
+bin
+obj
+/packages
+
+# Ignore Node & Bower
+###################
 node_modules
+bower_components
+build
+.tmp
+
+# Ignore Test reporters
+###################
+**/test/coverage
+report
+
+# Ignore Web Storm #
+.idea
+
+# Compiled source #
+###################
+*.com
+*.class
+*.dll
+*.exe
+*.o
+*.so
+
+# Packages #
+############
+# it's better to unpack these files and commit the raw source
+# git has its own built in compression methods
+*.7z
+*.dmg
+*.gz
+*.iso
+*.jar
+*.rar
+*.tar
+*.xap
+*.zip
+
+# Logs and databases #
+######################
+*.log
+*.sql
+*.sqlite
+# *.sdf
+*.mdf
+*.ldf
+
+# OS generated files #
+######################
+.DS_Store*
+ehthumbs.db
+Icon?
+Thumbs.db
+
+# Custom             #
+######################
+.build
+dist
+*.mo
+
+# Not for packaging  #
+######################
+demo
+*.bat

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "homepage": "http://igorlino.github.io/elevatezoom-plus/",
     "docs": "http://igorlino.github.io/elevatezoom-plus/examples",
     "demo": "http://igorlino.github.io/elevatezoom-plus/examples",
-    "dependencies": {
+    "peerDependencies": {
         "jquery": ">=2.1.4"
     },
     "devDependencies": {


### PR DESCRIPTION
This patch improves the results of `npm install ez-plus` by eliminating a couple of problems.

* First of all, the `.npmignore` file is patched to contain all of the `.gitignore` entries and also `demo` and `start.bat`. This change should prevent `npm` from packaging and installing of `.idea` (24 kiB), `demo` (1492 kiB), `start.bat` (Windows-only) and thus make the end users of the package slightly happier. (That stuff makes sense in the repo, but not in a package.)

* This patch also moves `jquery` from the `dependencies` section of `package.json` to `peerDependencies`. Both of these packages (`ez-plus` and `jquery`) are quite likely to be defined as dependencies of their common parent application (which is, most likely, a web site; could also be an application built on [Electron](http://electron.atom.io/), [NW.js](http://nwjs.io/), [JXcore for Cordova](https://github.com/jxcore/jxcore-cordova/), etc.) and thus to become peers in that sense. Currently, if some version mismatch happens on that level (under that parent), `npm` would install yet another version of `jquery` under `ez-plus` (and that would be the version required by `ez-plus` in its `dependencies`). However, because `ez-plus` does not rely on Node.js `require()` to grab jQuery, that npm's behaviour does not really help anything, and thus `npm` should rather **warn** on version mismatch, like it does with declared `peerDependencies`.

Neither minor version nor patch version of the package is changed because I am not sure about the severity of my patch on the scale of [semantic versioning](http://semver.org/).