### PR TITLE
Add main property to package.json to support vanilla require statement

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
     "name": "ez-plus",
+    "main": "src/jquery.ez-plus.js",
     "title": "EZ Plus",
     "version": "1.1.21",
     "description": "A jQuery image zoom plug-in, with tints, easing and gallery integration.",


### PR DESCRIPTION
Currently you need to do `require('ez-plus/src/jquery.ez-plus.js')` to require the lib file. This would be shortened to `require('ez-plus')` with this property in package.json.