### PR TITLE
fix(inline-styles) zindex is not valid

### DIFF
--- a/src/jquery.ez-plus.js
+++ b/src/jquery.ez-plus.js
@@ -207,7 +207,7 @@ if (typeof Object.create !== 'function') {
                     'background-repeat: no-repeat;' +
                     'cursor:' + (self.options.cursor) + ';' +
                     'overflow: hidden;' +
-                    'zindex: ' + self.options.zIndex + '    ;'  ;
+                    'z-index: ' + self.options.zIndex + '    ;'  ;
             }
 
             //if inner  zoom


### PR DESCRIPTION
zindex -> z-index (typo)

There was a typo which declared `zindex`. I'm not sure if this addresses any issues but it fixes the general typo