### PR TITLE
fix(code) lensRound default object

### DIFF
--- a/src/jquery.ez-plus.js
+++ b/src/jquery.ez-plus.js
@@ -270,7 +270,7 @@ if (typeof Object.create !== 'function') {
             };
 
             //lens style for lens zoom with optional round for modern browsers
-            self.lensRound = '';
+            self.lensRound = {};
 
             if (self.options.zoomType === 'lens') {
                 self.lensStyle = {


### PR DESCRIPTION
lensRound was still a string but should be an empty object instead

I just noticed this when reviewing the merge. 