### PR TITLE
IE 11 Number.isInteger() error

### DIFF
--- a/src/jquery.ez-plus.js
+++ b/src/jquery.ez-plus.js
@@ -1155,8 +1155,9 @@ if (typeof Object.create !== 'function') {
                         self.yp = 0;
                     }
                     var interval = 16;
-                    if (Number.isInteger(parseInt(self.options.easing))) {
-                        interval = parseInt(self.options.easing);
+                    var easingInterval = parseInt(self.options.easing);
+                    if (typeof easingInterval === 'number' && isFinite(easingInterval) && Math.floor(easingInterval) === easingInterval) {
+                        interval = easingInterval;
                     }
                     //if loop not already started, then run it
                     if (!self.loop) {


### PR DESCRIPTION
IE 11 doesn't support Number.isInteger(). See compatibility [here](https://docs.microsoft.com/en-us/scripting/javascript/reference/number-isinteger-function-number-javascript).

As a result of this I see these errors in my JS error logs:

```
TypeError: Object doesn't support property or method 'isInteger'
```
The suggested fix is based on the Mozilla polyfill suggested [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isInteger).

I believe there is something odd going on here in the first place. According to the [documentation](http://igorlino.github.io/elevatezoom-plus/api.htm) easing should be a boolean. I assume this might be a backwards compatibility workaround. Not sure. Either way, this should fix the issue.