### PR TITLE
Fix zoom lens and window positioning inside dialog

### DIFF
--- a/src/jquery.ez-plus.js
+++ b/src/jquery.ez-plus.js
@@ -727,8 +727,8 @@ if (typeof Object.create !== 'function') {
                 width: self.nzWidth,  // new code
                 height: self.nzHeight // new code
             });
-            self.mouseLeft = parseInt(e.pageX - self.nzOffset.left);
-            self.mouseTop = parseInt(e.pageY - self.nzOffset.top);
+            self.mouseLeft = parseInt(e.pageX - self.pageOffsetX - self.nzOffset.left);
+            self.mouseTop = parseInt(e.pageY - self.pageOffsetY - self.nzOffset.top);
             //calculate the Location of the Lens
 
             //calculate the bound regions - but only if zoom window
@@ -795,8 +795,8 @@ if (typeof Object.create !== 'function') {
                 //if lens zoom
                 if (self.options.zoomType === 'lens') {
 
-                    self.windowLeftPos = ((e.pageX - self.nzOffset.left) * self.widthRatio - self.zoomLens.width() / 2) * -1;
-                    self.windowTopPos = ((e.pageY - self.nzOffset.top) * self.heightRatio - self.zoomLens.height() / 2) * -1;
+                    self.windowLeftPos = ((e.pageX - self.pageOffsetX - self.nzOffset.left) * self.widthRatio - self.zoomLens.width() / 2) * -1;
+                    self.windowTopPos = ((e.pageY - self.pageOffsetY - self.nzOffset.top) * self.heightRatio - self.zoomLens.height() / 2) * -1;
                     self.zoomLens.css({
                         backgroundPosition: '' + self.windowLeftPos + 'px ' + self.windowTopPos + 'px'
                     });
@@ -1099,8 +1099,8 @@ if (typeof Object.create !== 'function') {
 
             }
 
-            self.windowLeftPos = ((e.pageX - self.nzOffset.left) * self.widthRatio - self.zoomWindow.width() / 2) * -1;
-            self.windowTopPos = ((e.pageY - self.nzOffset.top) * self.heightRatio - self.zoomWindow.height() / 2) * -1;
+            self.windowLeftPos = ((e.pageX - self.pageOffsetX - self.nzOffset.left) * self.widthRatio - self.zoomWindow.width() / 2) * -1;
+            self.windowTopPos = ((e.pageY - self.pageOffsetY - self.nzOffset.top) * self.heightRatio - self.zoomWindow.height() / 2) * -1;
             if (self.Etoppos) {
                 self.windowTopPos = 0;
             }
@@ -1178,8 +1178,8 @@ if (typeof Object.create !== 'function') {
                                 self.xp = self.windowLeftPos;
                                 self.yp = self.windowTopPos;
 
-                                self.xp = ((e.pageX - self.nzOffset.left) * self.widthRatio - self.zoomWindow.width() / 2) * (-1);
-                                self.yp = (((e.pageY - self.nzOffset.top) * self.heightRatio - self.zoomWindow.height() / 2) * (-1));
+                                self.xp = ((e.pageX - self.pageOffsetX - self.nzOffset.left) * self.widthRatio - self.zoomWindow.width() / 2) * (-1);
+                                self.yp = (((e.pageY - self.pageOffsetY - self.nzOffset.top) * self.heightRatio - self.zoomWindow.height() / 2) * (-1));
 
                                 if (self.changeBgSize) {
                                     if (self.nzHeight > self.nzWidth) {
@@ -1345,8 +1345,8 @@ if (typeof Object.create !== 'function') {
             var zoomLensWidth = self.zoomLens.width();
             var zoomLensHeight = self.zoomLens.height();
             self.updateOffset(self);
-            self.tintpos = ((e.pageX - self.nzOffset.left) - (zoomLensWidth / 2)) * -1;
-            self.tintposy = ((e.pageY - self.nzOffset.top) - zoomLensHeight / 2) * -1;
+            self.tintpos = ((e.pageX - self.pageOffsetX - self.nzOffset.left) - (zoomLensWidth / 2)) * -1;
+            self.tintposy = ((e.pageY - self.pageOffsetY - self.nzOffset.top) - zoomLensHeight / 2) * -1;
             if (self.Etoppos) {
                 self.tintposy = 0;
             }
@@ -1898,8 +1898,22 @@ if (typeof Object.create !== 'function') {
                 self.nzOffset.top = self.$elem.offset().top - appendedPosition.top;
                 self.nzOffset.left = self.$elem.offset().left - appendedPosition.left;
 
+                // NOTE: When initialising ezPlus on an element
+                // present inside a dialog the positions will
+                // not be correct unless the dialog occupies the
+                // entire viewport. These page offsets will help
+                // zoom lens and zoom window to be positioned
+                // correctly
+
+                // Update page offsets
+                self.pageOffsetX = appendedPosition.left;
+                self.pageOffsetY = appendedPosition.top;
             } else {
                 self.nzOffset = self.$elem.offset();
+
+                // Update page offsets
+                self.pageOffsetX = 0;
+                self.pageOffsetY = 0;
             }
         },
 


### PR DESCRIPTION
When initialising ezPlus on an element present inside a dialog the positions will not be correct unless the dialog occupies the entire viewport. These page offsets will help zoom lens and zoom window to be positioned correctly