### PR TITLE
Fix: only same container with identical ID needs to be removed. Issue…

### DIFF
--- a/src/jquery.ez-plus.js
+++ b/src/jquery.ez-plus.js
@@ -317,7 +317,7 @@ if (typeof Object.create !== 'function') {
             if (self.$elem.attr('id')) {
                 self.zoomContainer.attr('id', self.$elem.attr('id') + '-' + self.options.container);
             }
-            $('.' + self.options.container).remove();
+            $('.' + self.options.container + '[uuid="' + self.options.zoomId + '"]').remove();
             $(self.options.zoomContainerAppendTo).append(self.zoomContainer);
 
             //this will add overflow hidden and contrain the lens on lens mode


### PR DESCRIPTION
In the current version, all containers with class self.options.container are removed if appending a new picture. I think, only the container with the same uuid needs to be removed (if available) - fix in line 320 … #120